### PR TITLE
nejucomo.tdd-passphrase-output-change

### DIFF
--- a/pyutil/scripts/passphrase.py
+++ b/pyutil/scripts/passphrase.py
@@ -74,4 +74,4 @@ def main():
     sys.stdout.write(passphrase)
     sys.stdout.write('\n')
 
-    sys.stderr.write(u"This passphrase encodes about %.0d bits.\n" % (bits,))
+    sys.stderr.write(u"This passphrase encodes about {:.0f} bits.\n".format(bits))

--- a/pyutil/scripts/passphrase.py
+++ b/pyutil/scripts/passphrase.py
@@ -4,7 +4,7 @@
 
 #  This file is part of pyutil; see README.rst for licensing terms.
 
-import argparse, math, random
+import argparse, math, random, sys
 
 from pyutil.mathutil import div_ceil
 
@@ -71,4 +71,7 @@ def main():
 
     passphrase, bits = gen_passphrase(args.bits, allwords)
 
-    print u"Your new password is: '%s'. It is worth about %.0d bits." % (passphrase, bits)
+    sys.stdout.write(passphrase)
+    sys.stdout.write('\n')
+
+    sys.stderr.write(u"This passphrase encodes about %.0d bits.\n" % (bits,))

--- a/pyutil/test/current/test_passphrase.py
+++ b/pyutil/test/current/test_passphrase.py
@@ -16,7 +16,10 @@ class Passphrase(unittest.TestCase):
     @patch('argparse.ArgumentParser')
     @patch('pyutil.scripts.passphrase.gen_passphrase')
     @patch('sys.stdout')
-    def test_main(self, m_stdout, m_gen_passphrase, m_ArgumentParser):
+    @patch('sys.stderr')
+    def test_main(self, m_stderr, m_stdout,
+                  m_gen_passphrase, m_ArgumentParser):
+
         m_args = m_ArgumentParser.return_value.parse_args.return_value
         m_args.dictionary = StringIO('alpha\nbeta\n')
         m_args.bits = 42
@@ -52,6 +55,9 @@ class Passphrase(unittest.TestCase):
 
         self.assertEqual(
             m_stdout.mock_calls,
-            [call.write(u"Your new password is: 'wombat'. " +
-                        "It is worth about 43 bits."),
+            [call.write(u"wombat"),
              call.write('\n')])
+
+        self.assertEqual(
+            m_stderr.mock_calls,
+            [call.write(u"This passphrase encodes about 43 bits.\n")])

--- a/pyutil/test/current/test_passphrase.py
+++ b/pyutil/test/current/test_passphrase.py
@@ -4,10 +4,9 @@
 #  This file is part of pyutil; see README.rst for licensing terms.
 
 import unittest
-import argparse
 from cStringIO import StringIO
 
-from mock import patch, call
+from mock import patch, call, ANY
 
 from pyutil.scripts import passphrase
 
@@ -18,7 +17,7 @@ class Passphrase(unittest.TestCase):
     @patch('pyutil.scripts.passphrase.gen_passphrase')
     @patch('sys.stdout')
     def test_main(self, m_stdout, m_gen_passphrase, m_ArgumentParser):
-        m_args = m_ArgumentParser.parse_args.return_value
+        m_args = m_ArgumentParser.return_value.parse_args.return_value
         m_args.dictionary = StringIO('alpha\nbeta\n')
         m_args.bits = 42
 
@@ -38,20 +37,14 @@ class Passphrase(unittest.TestCase):
                  help=('what file to read a list of words from ' +
                        "(or omit this option to use passphrase's " +
                        'bundled dictionary)'),
-                 type=argparse.FileType('rU'),
+                 type=ANY,
                  metavar="DICT"),
              call().add_argument(
                  'bits',
                  help="how many bits of entropy minimum",
                  type=float,
                  metavar="BITS"),
-             call().parse_args(),
-
-             # BUG: Can we remove this layer of specificity?
-             # Why doesn't m_args remove this layer of specificity?
-             call().parse_args().__nonzero__(),
-             call().parse_args().readlines(),
-             call().parse_args().readlines().__iter__()])
+             call().parse_args()])
 
         self.assertEqual(
             m_gen_passphrase.mock_calls,
@@ -60,4 +53,5 @@ class Passphrase(unittest.TestCase):
         self.assertEqual(
             m_stdout.mock_calls,
             [call.write(u"Your new password is: 'wombat'. " +
-                        "It is worth about 42 bits.\n")])
+                        "It is worth about 43 bits."),
+             call.write('\n')])

--- a/pyutil/test/current/test_passphrase.py
+++ b/pyutil/test/current/test_passphrase.py
@@ -1,0 +1,63 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
+
+#  This file is part of pyutil; see README.rst for licensing terms.
+
+import unittest
+import argparse
+from cStringIO import StringIO
+
+from mock import patch, call
+
+from pyutil.scripts import passphrase
+
+
+class Passphrase(unittest.TestCase):
+
+    @patch('argparse.ArgumentParser')
+    @patch('pyutil.scripts.passphrase.gen_passphrase')
+    @patch('sys.stdout')
+    def test_main(self, m_stdout, m_gen_passphrase, m_ArgumentParser):
+        m_args = m_ArgumentParser.parse_args.return_value
+        m_args.dictionary = StringIO('alpha\nbeta\n')
+        m_args.bits = 42
+
+        m_gen_passphrase.return_value = ('wombat', 43)
+
+        passphrase.main()
+
+        self.assertEqual(
+            m_ArgumentParser.mock_calls,
+            [call(
+                prog='passphrase',
+                description=('Create a random passphrase by ' +
+                             'picking a few random words.')),
+             call().add_argument(
+                 '-d',
+                 '--dictionary',
+                 help=('what file to read a list of words from ' +
+                       "(or omit this option to use passphrase's " +
+                       'bundled dictionary)'),
+                 type=argparse.FileType('rU'),
+                 metavar="DICT"),
+             call().add_argument(
+                 'bits',
+                 help="how many bits of entropy minimum",
+                 type=float,
+                 metavar="BITS"),
+             call().parse_args(),
+
+             # BUG: Can we remove this layer of specificity?
+             # Why doesn't m_args remove this layer of specificity?
+             call().parse_args().__nonzero__(),
+             call().parse_args().readlines(),
+             call().parse_args().readlines().__iter__()])
+
+        self.assertEqual(
+            m_gen_passphrase.mock_calls,
+            [call(42, {u'alpha', u'beta'})])
+
+        self.assertEqual(
+            m_stdout.mock_calls,
+            [call.write(u"Your new password is: 'wombat'. " +
+                        "It is worth about 42 bits.\n")])

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(name=PKG,
       install_requires=install_requires,
       tests_require=[
           u'twisted >= 15.5.0',  # for trial (eg user: test_observer)
+          u'mock >= 1.3.0',
       ],
       classifiers=trove_classifiers,
       entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ data_files = [
     (os.path.join(u'pyutil', u'data'), [os.path.join(u'pyutil', u'data', u'wordlist.txt')])
     ]
 
-install_requires=[u'zbase32 >= 1.0']
+install_requires = [
+    u'zbase32 >= 1.0',
+    u'simplejson >= 2.1.0',
+]
 
 readmetext_bytes = open(u'README.rst').read()
 readmetext_unicode = readmetext_bytes.decode('utf-8')
@@ -68,6 +71,9 @@ setup(name=PKG,
       data_files=data_files,
       extras_require={u'jsonutil': [u'simplejson >= 2.1.0',]},
       install_requires=install_requires,
+      tests_require=[
+          u'twisted >= 15.5.0',  # for trial (eg user: test_observer)
+      ],
       classifiers=trove_classifiers,
       entry_points = {
           u'console_scripts': [


### PR DESCRIPTION
This is a superset of #2 which separates the entropy reporting onto stderr, leaving only the passphrase (and a newline) on stdout. This makes it more convenient to pipe the output to other utilities, eg: `passphrase 128 | xclip -in`.
